### PR TITLE
fix broken provides; also use modern META filename

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,14 +1,12 @@
 {
     "perl" : "6.*",
     "name" : "App::jsonv",
-    "version" : "0.01",
+    "version" : "0.02",
     "description" : "A command line JSON validator app",
     "author" : [ "David Farrell", "Dmitry Yaskolko" ],
     "source-type": "git",
     "source-url" : "git://github.com/Miniconf/App-jsonv.git",
     "depends" : [ "JSON::Tiny" ],
-    "provides" : {
-      "jsonv" : "App-jsonv/bin/jsonv"
-    }
+    "provides" : {}
 }
 


### PR DESCRIPTION
The provides field does not include the dist name, so no 'App-jsonv/'
Also, binaries aren't listed in it, only packages